### PR TITLE
assistants API file upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# https://astra.datastax.com/  ---> tokens on the left panel   ---> create an administrator user 
+export ASTRA_DB_APPLICATION_TOKEN=<ASTRA_CS:...>
+# https://platform.openai.com/api-keys
+export OPENAI_API_KEY=<sk-...>

--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ pytest==8.1.1
 typer==0.9.0
 # typing_extensions==4.10.0
 datasets==2.18.0
+openai==1.14.1
+streaming-assistants==0.14.0
+python-dotenv==1.0.1

--- a/swe_bench_util/cli.py
+++ b/swe_bench_util/cli.py
@@ -73,10 +73,77 @@ def maybe_clone(repo_url, repo_dir):
 def checkout_commit(repo_dir, commit_hash):
     subprocess.run(['git', 'checkout', commit_hash], cwd=repo_dir, check=True)
 
+exclude_exts: list[str] = [
+    ".min.js",
+    ".min.js.map",
+    ".min.css",
+    ".min.css.map",
+    ".tfstate",
+    ".tfstate.backup",
+    ".jar",
+    ".ipynb",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".download",
+    ".gif",
+    ".bmp",
+    ".tiff",
+    ".ico",
+    ".mp3",
+    ".wav",
+    ".wma",
+    ".ogg",
+    ".flac",
+    ".mp4",
+    ".avi",
+    ".mkv",
+    ".mov",
+    ".patch",
+    ".patch.disabled",
+    ".wmv",
+    ".m4a",
+    ".m4v",
+    ".3gp",
+    ".3g2",
+    ".rm",
+    ".swf",
+    ".flv",
+    ".iso",
+    ".bin",
+    ".tar",
+    ".zip",
+    ".7z",
+    ".gz",
+    ".rar",
+    ".pdf",
+    ".doc",
+    ".docx",
+    ".xls",
+    ".xlsx",
+    ".ppt",
+    ".pptx",
+    ".svg",
+    ".parquet",
+    ".pyc",
+    ".pub",
+    ".pem",
+    ".ttf",
+    ".dfn",
+    ".dfm",
+    ".feature",
+    "sweep.yaml",
+    "pnpm-lock.yaml",
+    "LICENSE",
+    "poetry.lock",
+]
 def upload_file(file_path):
     # Your processing logic for each file
     print(f"Processing {file_path}")
     try:
+        if any(file_path.endswith(ext) for ext in exclude_exts):
+            print(f"Skipping {file_path} because it has an excluded extension")
+            return None
         file = client.files.create(
             file=open(
                 file_path,


### PR DESCRIPTION
Added a new cli command `process-repo-files` which clones the repo, switches to the right commit hash, and iterates [sequentially for now] over all the files, uploading them to assistants-api. This gets us embeddings and RAG for free: 

    python -m swe_bench_util process-repo-files

I clone to /tmp for now, not sure if that's what we want.

In the end it dumps a list of file_ids that you can give your assistant for searching.

If this is interesting I'm happy to help optimize how assistants chunks and embeds for our purposes.